### PR TITLE
reflex: keep generated syscalls on SIGSYS route

### DIFF
--- a/patches/base/kuser_shared_data_patch.c
+++ b/patches/base/kuser_shared_data_patch.c
@@ -81,8 +81,7 @@ static void patch_kuser_shared_data(void) {
 
     *(UINT32*)(kuser + 0xFFC) = 0x13371337;
 
-    // Patch usage of syscalls
-    // 0 = syscalls take slow route, everything gets hooked
-    // 1 = syscalls take fast route unless ntdll.dll gets modified (default)
-    //user_shared_data[0x308] = 1;
+    /* Keep generated ntdll stubs on the syscall/SIGSYS route. Wine's
+     * default value of 1 selects int 0x2e, which cannot be redirected. */
+    *(UINT32 *)(kuser + 0x308) = 0;
 }


### PR DESCRIPTION
This fixes UNO, maybe a few others where “modern” reflex.dll also uses syscall redirects (see its reflex.ini)

In my tests I saw no regression on legacy enabled build, but worth double checking across more titles. If problematic we could also explore putting this behind a launch arg. 

- keep modern Reflex-generated ntdll stubs on the `syscall`/SIGSYS path
- avoid Wine's default `int 0x2e` path, which cannot redirect calls from the generated fake ntdll mapping

Testing:

- targeted `ntdll.so` build with `--without-unwind`
- UNO reached active card gameplay for multiple 90–180 second COW-prefix runs
- no `0xc0000005`, stack overflow, or unhandled exception in the final run
- 45-second COW-prefix matrix: Final Fantasy Tactics, Hello Kitty, Persona 3 Reload, Elliot, LADP, Yakuza Kiwami 3, and Bravely Default; all stayed live with render markers and no access violations/stack overflows