### PR TITLE
cachyos: resolve latest stable release tag instead of WIP branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Uses `linuwux_hooks_legacy.c` instead of the modern file (same symbols, same stu
 
 | Variant | Source | Default |
 |---------|--------|--------|
-| `cachyos` (default) | CachyOS/proton-cachyos | latest `cachyos_*/main` |
+| `cachyos` (default) | CachyOS/proton-cachyos | latest `cachyos-*-slr` / `-native` release tag |
 | `ge` | GloriousEggroll/proton-ge-custom | latest `GE-ProtonN-M` tag |
 
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ Usage:
   $(basename "$0") [OPTIONS] [VARIANT] [BRANCH/TAG]
 
 Variants:
-  cachyos (default)   CachyOS Proton (latest cachyos_*/main if no branch)
+  cachyos (default)   CachyOS Proton (latest cachyos-*-slr/-native release tag if no branch)
   ge                  GloriousEggroll Proton (latest GE-ProtonN-M tag if no tag)
 
 Examples:

--- a/lib/source.sh
+++ b/lib/source.sh
@@ -2,23 +2,26 @@
 # Source tree management: version resolution, clone, submodules, patch staging.
 # Sourced by build.sh — requires lib/common.sh already loaded.
 
-detect_latest_cachyos_branch() {
-    local fallback="$1" latest
-    command -v git >/dev/null 2>&1 || { echo "$fallback"; return; }
-    latest=$(git ls-remote --heads "$REPO" 'refs/heads/cachyos_*' 2>/dev/null \
-        | sed 's|.*refs/heads/||' \
-        | grep '/main$' \
-        | sort -t_ -k3 \
-        | tail -1)
-    [[ -n "$latest" ]] && echo "$latest" || echo "$fallback"
-}
-
 detect_latest_ge_tag() {
     local fallback="master" latest
     command -v git >/dev/null 2>&1 || { echo "$fallback"; return; }
     latest=$(git ls-remote --tags "$REPO" 'refs/tags/GE-Proton*' 2>/dev/null \
         | sed 's|.*refs/tags/||' \
         | grep -E '^GE-Proton[0-9]+-[0-9]+$' \
+        | sort -V \
+        | tail -1)
+    [[ -n "$latest" ]] && echo "$latest" || echo "$fallback"
+}
+
+detect_latest_cachyos_tag() {
+    local fallback="$1" latest
+    command -v git >/dev/null 2>&1 || { echo "$fallback"; return; }
+    # Stable release tags (cachyos-<ver>-<date>-slr / -native). The WIP
+    # cachyos_*/main branches are not consistently buildable (broken wine
+    # submodule URL, dropped seccomp rules), so prefer tagged releases.
+    latest=$(git ls-remote --tags "$REPO" 'refs/tags/cachyos-*' 2>/dev/null \
+        | sed 's|.*refs/tags/||' \
+        | grep -E '^cachyos-[0-9]+\.[0-9]+-[0-9]+-(slr|native)$' \
         | sort -V \
         | tail -1)
     [[ -n "$latest" ]] && echo "$latest" || echo "$fallback"
@@ -85,7 +88,7 @@ resolve_repo_and_branch() {
         cachyos|cachy)
             VARIANT="cachyos"
             REPO="https://github.com/CachyOS/proton-cachyos.git"
-            DEFAULT_BRANCH="cachyos_11.0_20260702/main"
+            DEFAULT_BRANCH="cachyos-11.0-20260703-slr"
             ;;
         ge|proton-ge|eggroll)
             VARIANT="ge"
@@ -96,9 +99,9 @@ resolve_repo_and_branch() {
 
     if [[ -z "$BRANCH" ]]; then
         if [[ "$VARIANT" == "cachyos" ]]; then
-            info "Resolving latest CachyOS branch from remote..."
-            DEFAULT_BRANCH=$(detect_latest_cachyos_branch "$DEFAULT_BRANCH")
-            info "  Using branch: $DEFAULT_BRANCH"
+            info "Resolving latest CachyOS stable release tag from remote..."
+            DEFAULT_BRANCH=$(detect_latest_cachyos_tag "$DEFAULT_BRANCH")
+            info "  Using tag: $DEFAULT_BRANCH"
         else
             info "Resolving latest GE-Proton tag from remote..."
             DEFAULT_BRANCH=$(detect_latest_ge_tag)


### PR DESCRIPTION
## Summary

The default `cachyos` variant resolves the latest `cachyos_*/main` branch from the CachyOS repo. Those branches are work-in-progress snapshots and are not consistently buildable (see issue #9):

1. **Broken wine submodule URL** — WIP branches use `url = ../wine`, which resolves to the non-existent `CachyOS/wine` instead of the public `CachyOS/wine-cachyos`.
2. **Dropped seccomp top-down trap** on `20260724` — breaks LinUwUx's SIGSYS routing (games fail with "Initialization error 5").

This PR makes the cachyos variant resolve the **latest stable release tag** (`cachyos-*-slr` / `cachyos-*-native`), mirroring how the GE variant already resolves `GE-ProtonN-M` tags. Stable releases use the correct wine submodule URL and retain the seccomp trap.

## Changes

- **`lib/source.sh`**
  - Remove `detect_latest_cachyos_branch()` (WIP branch resolution)
  - Add `detect_latest_cachyos_tag()` — queries `refs/tags/cachyos-*-(slr|native)`, sorts with `sort -V`
  - Update `resolve_repo_and_branch()` to use the tag resolver
  - Update the fallback `DEFAULT_BRANCH` to `cachyos-11.0-20260703-slr`
- **`build.sh`** / **`README.md`** — update wording: latest release tag instead of latest branch

## Test

```bash
./build.sh cachyos            # resolves latest stable tag, e.g. cachyos-11.0-20260703-slr
./build.sh cachyos cachyos_11.0_20260724/main   # still allows explicit branch override
```

## Related

- Closes issue #9 (Option A)
