### PR TITLE
sigsys: fix reflex trampoline resume (rax = code addr, not guest arg)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 #   package.sh        – user_settings, configure, redist, verify
 # ============================================================
 
-VERSION="26.08.08"
+VERSION="26.08.09"
 CONTAINER_ENGINE="podman"
 PATCH_REPO="https://github.com/brcly/proton-LinUwUx-patch.git"
 PATCH_BRANCH="${PATCH_BRANCH:-main}"

--- a/patches/base/linuwux_hooks.c
+++ b/patches/base/linuwux_hooks.c
@@ -33,6 +33,11 @@
  *   needs at least one redirect from that range (rax=0xffe).
  *   Set LINUWUX_REDIRECT_ALL=1 to restore pre-scope behaviour.
  *   Wine-system skips are intentional and not logged (too hot under DEBUG).
+ *
+ * Trampoline resume (dev/trampoline-resume-rip):
+ *   Default path in reflex does mov rcx,rax / sub rcx,2 / jmp rcx after
+ *   arming xmm5 bypass magic. RAX must be the re-entry code address
+ *   (SIGSYS RIP + 2), not a syscall argument.
  */
 #ifndef LINUWUX_HOOKS_INCLUDED
 #define LINUWUX_HOOKS_INCLUDED
@@ -352,10 +357,24 @@ static int linuwux_sigsys_route(void *sigcontext)
         linuwux_log("sigsys redirect rax=%llx rip=%llx → TargetSysHandler=%p\n",
                     syscall_nr, rip, (void *)TargetSysHandler);
 
-        xmm_regs[4] = ctx->uc_mcontext.gregs[REG_RAX] & 0xFFFFFFFF;
-        ctx->uc_mcontext.gregs[REG_RAX] = ctx->uc_mcontext.gregs[REG_RCX];
-        ctx->uc_mcontext.gregs[REG_RCX] = TargetSysHandler;
-        ctx->uc_mcontext.gregs[REG_RIP] = TargetSysHandler;
+        /*
+         * Protocol match for current reflex trampoline (RVA 0x1000):
+         *   mov rcx, rax
+         *   … special cases …
+         *   movq xmm5, 0x1337133713371337   ; bypass on re-issue
+         *   mov eax, r11d                  ; syscall nr from xmm4
+         *   sub rcx, 2
+         *   jmp rcx
+         *
+         * Linux SIGSYS reports RIP at the syscall insn (0F 05). Pass
+         * rip+2 in RAX so after sub 2 the trampoline re-enters that insn.
+         * Old behaviour (rax = guest rcx) treated an argument as a code
+         * pointer and caused execute AVs (e.g. 0x225FF on BL4 1.9).
+         */
+        xmm_regs[4] = syscall_nr & 0xFFFFFFFF;
+        ctx->uc_mcontext.gregs[REG_RAX] = (long long)(rip + 2);
+        ctx->uc_mcontext.gregs[REG_RCX] = (long long)TargetSysHandler;
+        ctx->uc_mcontext.gregs[REG_RIP] = (long long)TargetSysHandler;
         return 1;
     }
 

--- a/patches/base/linuwux_hooks.c
+++ b/patches/base/linuwux_hooks.c
@@ -36,8 +36,8 @@
  *
  * Trampoline resume (dev/trampoline-resume-rip):
  *   Default path in reflex does mov rcx,rax / sub rcx,2 / jmp rcx after
- *   arming xmm5 bypass magic. RAX must be the re-entry code address
- *   (SIGSYS RIP + 2), not a syscall argument.
+ *   arming xmm5 bypass magic. RAX must be a code address so after sub 2 we
+ *   land on the syscall insn — not a syscall argument.
  */
 #ifndef LINUWUX_HOOKS_INCLUDED
 #define LINUWUX_HOOKS_INCLUDED
@@ -339,6 +339,9 @@ static int linuwux_sigsys_route(void *sigcontext)
     __uint128_t *xmm_regs = (__uint128_t *)ctx->uc_mcontext.fpregs->_xmm;
     unsigned long long syscall_nr;
     unsigned long long rip;
+    unsigned long long resume;
+    unsigned char *ip;
+    unsigned char b0 = 0, b1 = 0;
 
     if (TargetSysHandler != 0 &&
         (xmm_regs[5] & 0xFFFFFFFFFFFFFFFF) != 0x1337133713371337) {
@@ -354,9 +357,6 @@ static int linuwux_sigsys_route(void *sigcontext)
         if (!linuwux_redirect_all_enabled() && linuwux_rip_is_wine_system(rip))
             return 0;
 
-        linuwux_log("sigsys redirect rax=%llx rip=%llx → TargetSysHandler=%p\n",
-                    syscall_nr, rip, (void *)TargetSysHandler);
-
         /*
          * Protocol match for current reflex trampoline (RVA 0x1000):
          *   mov rcx, rax
@@ -366,13 +366,23 @@ static int linuwux_sigsys_route(void *sigcontext)
          *   sub rcx, 2
          *   jmp rcx
          *
-         * Linux SIGSYS reports RIP at the syscall insn (0F 05). Pass
-         * rip+2 in RAX so after sub 2 the trampoline re-enters that insn.
-         * Old behaviour (rax = guest rcx) treated an argument as a code
-         * pointer and caused execute AVs (e.g. 0x225FF on BL4 1.9).
+         * RAX must be a code address so after sub 2 we land on the syscall
+         * insn. If SIGSYS RIP is already at 0F 05, pass rip+2; if RIP is
+         * already past the insn, pass rip as-is.
          */
+        ip = (unsigned char *)(uintptr_t)rip;
+        b0 = ip[0];
+        b1 = ip[1];
+        if (b0 == 0x0f && b1 == 0x05)
+            resume = rip + 2;
+        else
+            resume = rip;
+
+        linuwux_log("sigsys redirect rax=%llx rip=%llx bytes=%02x %02x resume=%llx → TargetSysHandler=%p\n",
+                    syscall_nr, rip, b0, b1, resume, (void *)TargetSysHandler);
+
         xmm_regs[4] = syscall_nr & 0xFFFFFFFF;
-        ctx->uc_mcontext.gregs[REG_RAX] = (long long)(rip + 2);
+        ctx->uc_mcontext.gregs[REG_RAX] = (long long)resume;
         ctx->uc_mcontext.gregs[REG_RCX] = (long long)TargetSysHandler;
         ctx->uc_mcontext.gregs[REG_RIP] = (long long)TargetSysHandler;
         return 1;

--- a/patches/base/linuwux_hooks.c
+++ b/patches/base/linuwux_hooks.c
@@ -378,8 +378,11 @@ static int linuwux_sigsys_route(void *sigcontext)
         else
             resume = rip;
 
-        linuwux_log("sigsys redirect rax=%llx rip=%llx bytes=%02x %02x resume=%llx → TargetSysHandler=%p\n",
-                    syscall_nr, rip, b0, b1, resume, (void *)TargetSysHandler);
+        linuwux_log("sigsys redirect rax=%llx rip=%llx resume=%llx → %p\n",
+                    syscall_nr, rip, resume, (void *)TargetSysHandler);
+        /* Neighbourhood dump: confirm whether 0F 05 sits at rip-2 (syscall; ret). */
+        linuwux_log("sigsys near -4=%02x %02x -2=%02x %02x | %02x %02x +2=%02x %02x\n",
+                    ip[-4], ip[-3], ip[-2], ip[-1], b0, b1, ip[2], ip[3]);
 
         xmm_regs[4] = syscall_nr & 0xFFFFFFFF;
         ctx->uc_mcontext.gregs[REG_RAX] = (long long)resume;


### PR DESCRIPTION
## Summary

Match the current DenuvOwO/reflex default trampoline path when routing SIGSYS.

The trampoline does:

    mov rcx, rax
    … special cases …
    movq xmm5, 0x1337133713371337   ; bypass on re-issue
    mov eax, r11d                  ; nr from xmm4
    sub rcx, 2
    jmp rcx

We previously set rax to the guest first argument (rcx). That made the default path jump to (arg − 2) and produced execute AVs (e.g. 0x225FF on BL4).

## Change

In linuwux_sigsys_route:

- Put the syscall number in xmm4 as before
- Set rax to a resume code address:
  - If fault RIP is 0F 05 → rip + 2
  - Otherwise → rip (typical case: RIP sits on the following ret, real syscall at rip − 2)
- Optional LINUWUX_DEBUG neighbourhood dump to confirm stub layout

In my testing, ACBFR works just fine, BL4 1.8.1 works just fine (without sys hack dll) however, BL4 1.9 is still currently broken.
