### PR TITLE
Add CI, reporting-issues/uninstall docs, and quote VERSION in build.sh

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,12 +1,12 @@
 name: Bug report
-description: Report an issue with liblinuwux_preload.so
+description: Report an issue with liblinuwux.so
 title: "[Bug]: "
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting an issue. Almost every bug we've actually been able to fix so far came from a debug log with `LINUWUX_DEBUG=1` set -- without it, none of `liblinuwux_preload.so`'s own `[linuwux-preload]` lines show up, and we're guessing blind. Please enable it before reproducing (see the Debug log field below).
+        Thanks for reporting an issue. Almost every bug we've actually been able to fix so far came from a debug log with `LINUWUX_DEBUG=1` set -- `liblinuwux.so` always announces its version on load, but the detailed `[linuwux]` event trace (CPUID vendor, WINEDLLOVERRIDES, registry writes, redirects) only shows up with `LINUWUX_DEBUG=1` set, and without it we're guessing blind. Please enable it before reproducing (see the Debug log field below).
 
   - type: dropdown
     id: launch-method
@@ -41,9 +41,9 @@ body:
     attributes:
       label: Exact launch options / command used
       description: |
-        Paste the exact LD_PRELOAD line and any other env vars you set. LD_PRELOAD should be appended, not replace the existing value -- a bare `LD_PRELOAD=/path/to/liblinuwux_preload.so %command%` silently drops Steam's own overlay preload entry:
+        Paste the exact LD_PRELOAD line and any other env vars you set. LD_PRELOAD should be appended, not replace the existing value -- a bare `LD_PRELOAD=/path/to/liblinuwux.so %command%` silently drops Steam's own overlay preload entry:
 
-        LD_PRELOAD="${LD_PRELOAD}:/path/to/liblinuwux_preload.so" %command%
+        LD_PRELOAD="${LD_PRELOAD}:/path/to/liblinuwux.so" %command%
       render: shell
     validations:
       required: true
@@ -53,7 +53,7 @@ body:
     attributes:
       label: Debug log
       description: |
-        Set `LINUWUX_DEBUG=1` and `PROTON_LOG=1` (Steam) or `UMU_LOG=1` (umu-run / Lutris / Heroic / Faugus / Bottles) before launching, reproduce the issue, then paste the full log here. Without `LINUWUX_DEBUG=1`, `liblinuwux_preload.so` won't print anything and we can't tell what it actually did.
+        Set `LINUWUX_DEBUG=1` and `PROTON_LOG=1` (Steam) or `UMU_LOG=1` (umu-run / Lutris / Heroic / Faugus / Bottles) before launching, reproduce the issue, then paste the full log here. Also include `linuwux --version` (or `strings liblinuwux.so | grep linuwux` if you built from source) -- without `LINUWUX_DEBUG=1`, `liblinuwux.so` only prints its version line, not the detailed trace we need to tell what it actually did.
       render: shell
     validations:
       required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Shell syntax check
+        run: |
+          bash -n build.sh
+          sh -n install.sh
+          sh -n src/linuwux.sh
+
+      - name: Shellcheck
+        run: shellcheck build.sh install.sh src/linuwux.sh
+
+      - name: Build liblinuwux.so (-Wall -Wextra)
+        run: gcc -std=gnu11 -O2 -fPIC -shared -Wall -Wextra -o /tmp/strict-check.so src/linuwux.c -ldl
+
+      - name: Build via build.sh
+        run: ./build.sh
+
+      - name: Verify export surface stays exactly the 4 interposed libc symbols
+        run: |
+          exports=$(nm -D dist/liblinuwux.so | awk '$2=="T"{print $3}' | sort)
+          expected=$(printf '%s\n' clock_gettime gettimeofday prctl sigaction | sort)
+          if [ "$exports" != "$expected" ]; then
+            echo "::error::Unexpected exported symbols -- LD_PRELOAD libraries should only export their interposition targets"
+            diff <(echo "$expected") <(echo "$exports")
+            exit 1
+          fi
+          echo "Export surface OK:"
+          echo "$exports"
+
+      - name: Smoke test --install and --version
+        run: |
+          export HOME="${RUNNER_TEMP}/fakehome"
+          mkdir -p "$HOME"
+          ./build.sh --install
+          "${HOME}/.local/bin/linuwux" --version

--- a/README.md
+++ b/README.md
@@ -161,12 +161,30 @@ With `--install`, also:
 
 Neither is a real "install" in the traditional sense — no compatibility-tool registration, nothing Proton or Steam needs to know about ahead of time. It's just a file to point a launch option at (see Quick start).
 
+To uninstall, just remove the two files:
+
+```bash
+rm -f ~/.local/lib/liblinuwux.so ~/.local/bin/linuwux
+```
+
+Then remove it from the game's launch options.
+
 ## Behaviour notes
 
 - `WINEDLLOVERRIDES` and `PROTON_DISABLE_LSTEAMCLIENT` are set live by the library itself at load time (see Runtime table above) — not baked into any script.
 - `PROTON_DISABLE_LSTEAMCLIENT=1` bypasses Steam DRM/Steamworks checks some DenuvOwO packs trip on. It doesn't affect the Steam Overlay — that keeps working as long as `LD_PRELOAD` is appended rather than replaced (see Quick start).
 - The library announces its version on every load (`[linuwux] vX.Y.Z loaded (pid=...)`, printed to stderr regardless of `LINUWUX_DEBUG`) so it shows up in whatever log gets pasted for a bug report. Check it any time without launching a game via `linuwux --version` or `strings liblinuwux.so | grep linuwux`.
 - Confirmed working launched directly through the real Steam client (not just Lutris/Heroic/Faugus) with GE-Proton/CachyOS — the game's `LD_PRELOAD` does reach the process inside Steam's own pressure-vessel container.
+
+## Reporting issues
+
+Open an [issue](https://github.com/brcly/linuwux-runtime/issues/new/choose) and include:
+
+- `linuwux --version` (or `strings liblinuwux.so | grep linuwux` if you built from source)
+- A `LINUWUX_DEBUG=1` run — set it before launching, either as a Steam launch option prefix (`LINUWUX_DEBUG=1 ~/.local/bin/linuwux %command%`) or via `LINUWUX_DEBUG=1 linuwux <game exe>` from a terminal — and paste the resulting log
+- GE-Proton/CachyOS version, and whether it's a Denuvo pack, another DRM, or something else
+
+Without the version and a debug log, diagnosing a report usually starts with a guess.
 
 ## License
 

--- a/build.sh
+++ b/build.sh
@@ -126,7 +126,7 @@ build_linuwux() {
     need gcc
 
     mkdir -p "$DIST_DIR"
-    gcc -std=gnu11 -O2 -fPIC -shared -Wall -DLINUWUX_VERSION=\"${VERSION}\" \
+    gcc -std=gnu11 -O2 -fPIC -shared -Wall -DLINUWUX_VERSION=\""${VERSION}"\" \
         -o "$out" "$SRC" -ldl \
         || die "Failed to compile liblinuwux.so"
 


### PR DESCRIPTION
- .github/workflows/ci.yml: build + shellcheck + export-surface check + install/--version smoke test on every push/PR, not just tagged releases -- catches broken commits before they land on main
- README: "Reporting issues" section (version + LINUWUX_DEBUG=1 log) and uninstall instructions
- build.sh: quote the VERSION expansion in the gcc -D flag (silences shellcheck SC2086, defensive against a version string with spaces)
- bug_report.yml: drop stale liblinuwux_preload.so/[linuwux-preload] naming, correct the claim that nothing prints without LINUWUX_DEBUG=1 (the version line is now unconditional), and ask for linuwux --version in the debug-log field