### PR TITLE
Scoped game + reflex detection

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ set -euo pipefail
 # Baked into the .so as LINUWUX_VERSION -- announced on load and readable
 # via 'linuwux --version'. LINUWUX_VERSION_OVERRIDE lets the release
 # workflow stamp the exact tag without editing this file.
-VERSION="${LINUWUX_VERSION_OVERRIDE:-26.08.14.1}"
+VERSION="${LINUWUX_VERSION_OVERRIDE:-26.08.14.2}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_DIR="${SCRIPT_DIR}/src"

--- a/src/linuwux.c
+++ b/src/linuwux.c
@@ -18,21 +18,19 @@
  */
 
 /*
- * linuwux — LD_PRELOAD library for DenuvOwO/LinUwUx under Wine/Proton.
- *
- * Hooks: sigaction, prctl, clock_gettime, gettimeofday.
- * Provides: CPUID spoof, SIGSYS redirect, HwProfileGuid, DLL overrides, faketime.
+ * linuwux — LD_PRELOAD library for DenuvOwO under Wine/Proton.
+ * Constructor only; modules/ holds hooks, cpuid, sigsys, registry, faketime.
  * Debug: LINUWUX_DEBUG=1
- *
- * Source is split by concern under modules/: cpuid.c, sigsys.c,
- * registry.c, faketime.c, hooks.c, common.c. This file is just the
- * constructor.
  */
 
 #define _GNU_SOURCE
+#include <ctype.h>
+#include <dirent.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <unistd.h>
 
 #include "modules/linuwux.h"
@@ -55,35 +53,120 @@ static void linuwux_append_override(char *buf, size_t bufsize, const char *entry
         linuwux_log("WINEDLLOVERRIDES: not enough room to append \"%s\" -- skipping\n", entry);
 }
 
+/* is_game: argv[1] Windows path with reflex.dll in the same directory. */
+static int linuwux_dir_has_reflex(const char *dir)
+{
+    DIR *d;
+    struct dirent *ent;
+    int found = 0;
+
+    d = opendir(dir);
+    if (!d)
+        return 0;
+
+    while ((ent = readdir(d))) {
+        if (!strcasecmp(ent->d_name, "reflex.dll")) {
+            found = 1;
+            break;
+        }
+    }
+    closedir(d);
+
+    return found;
+}
+
+static int linuwux_game_dir_has_reflex(const char *argv0)
+{
+    const char *prefix;
+    char path[PATH_MAX];
+    char drive;
+    char *slash;
+    size_t i;
+    int found;
+
+    if (!argv0 || !argv0[0] || argv0[1] != ':') {
+        linuwux_log("is_game: argv path missing or not X:\\... (%s)\n",
+                    argv0 ? argv0 : "(null)");
+        return 0;
+    }
+
+    drive = (char)tolower((unsigned char)argv0[0]);
+
+    /* Z: = host filesystem root; skip dosdevices. */
+    if (drive == 'z') {
+        if (snprintf(path, sizeof(path), "%s", argv0 + 2) >= (int)sizeof(path))
+            return 0;
+    } else {
+        /* dosdevices/<drive>: */
+        prefix = getenv("WINEPREFIX");
+        if (!prefix) {
+            linuwux_log("is_game: no WINEPREFIX for drive %c:\n", drive);
+            return 0;
+        }
+
+        if (snprintf(path, sizeof(path), "%s/dosdevices/%c:%s", prefix, drive, argv0 + 2) >= (int)sizeof(path))
+            return 0;
+    }
+
+    for (i = 0; path[i]; i++)
+        if (path[i] == '\\')
+            path[i] = '/';
+
+    slash = strrchr(path, '/');
+    if (!slash)
+        return 0;
+    *slash = '\0';
+
+    found = linuwux_dir_has_reflex(path);
+    linuwux_log("is_game: dir=%s reflex=%s\n", path, found ? "yes" : "no");
+    return found;
+}
+
+/* GNU constructor extension: glibc passes real argc/argv/envp. */
 __attribute__((constructor))
-static void linuwux_init(void)
+static void linuwux_init(int argc, char **argv, char **envp)
 {
     char overrides[4096];
     const char *existing;
-    int n;
+    int n, is_game;
 
-    linuwux_detect_cpu_vendor();
+    (void)envp;
 
-    /* Append our DLL overrides without clobbering user-set keys. */
-    existing = getenv("WINEDLLOVERRIDES");
-    n = snprintf(overrides, sizeof(overrides), "%s", existing ? existing : "");
-    if (existing && (n < 0 || (size_t)n >= sizeof(overrides)))
-        linuwux_log("WINEDLLOVERRIDES: existing value (%zu bytes) doesn't fit our %zu-byte buffer -- truncated\n",
-                     strlen(existing), sizeof(overrides));
+    /* Wine: argv[0] is the loader; argv[1] is the Windows target path. */
+    is_game = linuwux_game_dir_has_reflex(argc > 1 ? argv[1] : NULL);
+    linuwux_log("is_game: argv[1]=%s -> %s\n",
+                (argc > 1 && argv[1]) ? argv[1] : "(none)",
+                is_game ? "game" : "helper");
+    linuwux_set_game_process(is_game);
 
-    if (!existing || !strstr(existing, "winmm="))
-        linuwux_append_override(overrides, sizeof(overrides), "winmm=n,b");
-    if (!existing || !strstr(existing, "version="))
-        linuwux_append_override(overrides, sizeof(overrides), "version=n,b");
-    if (!existing || !strstr(existing, "reflex="))
-        linuwux_append_override(overrides, sizeof(overrides), "reflex=n,b");
+    /* Spoof leaves only needed in the game process (CPUID path gated). */
+    if (is_game)
+        linuwux_detect_cpu_vendor();
 
-    setenv("WINEDLLOVERRIDES", overrides, 1);
-    linuwux_log("WINEDLLOVERRIDES=\"%s\"\n", overrides);
+    /* Overrides only in the game process (Wine reads env at PE load). */
+    if (is_game) {
+        /* Append our DLL overrides without clobbering user-set keys. */
+        existing = getenv("WINEDLLOVERRIDES");
+        n = snprintf(overrides, sizeof(overrides), "%s", existing ? existing : "");
+        if (existing && (n < 0 || (size_t)n >= sizeof(overrides)))
+            linuwux_log("WINEDLLOVERRIDES: existing value (%zu bytes) doesn't fit our %zu-byte buffer -- truncated\n",
+                         strlen(existing), sizeof(overrides));
 
-    /* Default on for DenuvOwO; user can set 0. Overlay does not need lsteamclient. */
+        if (!existing || !strstr(existing, "winmm="))
+            linuwux_append_override(overrides, sizeof(overrides), "winmm=n,b");
+        if (!existing || !strstr(existing, "version="))
+            linuwux_append_override(overrides, sizeof(overrides), "version=n,b");
+        if (!existing || !strstr(existing, "reflex="))
+            linuwux_append_override(overrides, sizeof(overrides), "reflex=n,b");
+
+        setenv("WINEDLLOVERRIDES", overrides, 1);
+        linuwux_log("WINEDLLOVERRIDES=\"%s\"\n", overrides);
+    }
+
+    /* Global: Proton may read this before any Wine process starts. */
     setenv("PROTON_DISABLE_LSTEAMCLIENT", "1", 0);
 
-    /* Always print version (not only under LINUWUX_DEBUG) for bug reports. */
-    fprintf(stderr, "[linuwux] v%s loaded (pid=%d)\n", LINUWUX_VERSION, getpid());
+    /* Version banner only for the game process. */
+    if (is_game)
+        fprintf(stderr, "[linuwux] v%s loaded (pid=%d)\n", LINUWUX_VERSION, getpid());
 }

--- a/src/modules/common.c
+++ b/src/modules/common.c
@@ -28,10 +28,23 @@
 
 #include "linuwux.h"
 
+/* Default 1 so test harnesses without set_game_process still log. */
+static int g_is_game_process = 1;
+
+void linuwux_set_game_process(int is_game)
+{
+    g_is_game_process = is_game;
+}
+
+int linuwux_is_game_process(void)
+{
+    return g_is_game_process;
+}
+
 void linuwux_log(const char *fmt, ...)
 {
     va_list ap;
-    if (!getenv("LINUWUX_DEBUG"))
+    if (!g_is_game_process || !getenv("LINUWUX_DEBUG"))
         return;
     fprintf(stderr, "[linuwux] ");
     va_start(ap, fmt);

--- a/src/modules/cpuid.c
+++ b/src/modules/cpuid.c
@@ -164,6 +164,21 @@ static void linuwux_patch_kuser_shared_data(void)
     linuwux_log("kuser_shared_data: patched\n");
 }
 
+/* Real CPUID with faulting briefly disabled. */
+static void linuwux_cpuid_passthrough(ucontext_t *ctx, unsigned int leaf, unsigned int subleaf)
+{
+    syscall(SYS_arch_prctl, ARCH_SET_CPUID, 1);
+    __asm__ volatile(
+        "cpuid"
+        : "=a"(ctx->uc_mcontext.gregs[REG_RAX]),
+          "=b"(ctx->uc_mcontext.gregs[REG_RBX]),
+          "=c"(ctx->uc_mcontext.gregs[REG_RCX]),
+          "=d"(ctx->uc_mcontext.gregs[REG_RDX])
+        : "a"(leaf), "c"(subleaf)
+        : "memory");
+    syscall(SYS_arch_prctl, ARCH_SET_CPUID, 0);
+}
+
 /* DenuvOwO protocol leaves (not real CPUID leaves). */
 #define LINUWUX_CPUID_LEAF_ARM      0x336933
 #define LINUWUX_CPUID_LEAF_FAKETIME 0x336967
@@ -181,6 +196,13 @@ int linuwux_cpuid_spoof(siginfo_t *info, ucontext_t *ctx)
 
     if (!info || info->si_code != SI_KERNEL)
         return 0;
+
+    if (!linuwux_redirect_all_enabled() && linuwux_rip_is_wine_system((unsigned long long)(uintptr_t)rip)) {
+        /* Wine system PE range — real CPUID, not spoof. */
+        linuwux_cpuid_passthrough(ctx, spoof_leaf, spoof_subleaf);
+        ctx->uc_mcontext.gregs[REG_RIP] += 2;
+        return 1;
+    }
 
     switch (spoof_leaf) {
     case 1:
@@ -246,17 +268,7 @@ int linuwux_cpuid_spoof(siginfo_t *info, ucontext_t *ctx)
         break;
 
     default:
-        /* Pass through real CPUID while faulting is briefly disabled. */
-        syscall(SYS_arch_prctl, ARCH_SET_CPUID, 1);
-        __asm__ volatile(
-            "cpuid"
-            : "=a"(ctx->uc_mcontext.gregs[REG_RAX]),
-              "=b"(ctx->uc_mcontext.gregs[REG_RBX]),
-              "=c"(ctx->uc_mcontext.gregs[REG_RCX]),
-              "=d"(ctx->uc_mcontext.gregs[REG_RDX])
-            : "a"(spoof_leaf), "c"(spoof_subleaf)
-            : "memory");
-        syscall(SYS_arch_prctl, ARCH_SET_CPUID, 0);
+        linuwux_cpuid_passthrough(ctx, spoof_leaf, spoof_subleaf);
     }
 
     ctx->uc_mcontext.gregs[REG_RIP] += 2;

--- a/src/modules/faketime.c
+++ b/src/modules/faketime.c
@@ -66,6 +66,9 @@ int clock_gettime(clockid_t id, struct timespec *ts)
     if (!real_clock_gettime)
         real_clock_gettime = (clock_gettime_fn)dlsym(RTLD_NEXT, "clock_gettime");
 
+    if (!linuwux_is_game_process())
+        return real_clock_gettime(id, ts);
+
     ret = real_clock_gettime(id, ts);
 
     if (ret == 0 && atomic_load(&g_faketime_active) &&
@@ -93,6 +96,9 @@ int gettimeofday(struct timeval *tv, void *tz)
 
     if (!real_gettimeofday)
         real_gettimeofday = (gettimeofday_fn)dlsym(RTLD_NEXT, "gettimeofday");
+
+    if (!linuwux_is_game_process())
+        return real_gettimeofday(tv, tz);
 
     ret = real_gettimeofday(tv, tz);
 

--- a/src/modules/hooks.c
+++ b/src/modules/hooks.c
@@ -110,6 +110,9 @@ int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
     if (!real_sigaction)
         real_sigaction = (sigaction_fn)dlsym(RTLD_NEXT, "sigaction");
 
+    if (!linuwux_is_game_process())
+        return real_sigaction(signum, act, oldact);
+
     if (act && signum == SIGSEGV && act->sa_sigaction != linuwux_segv_wrapper) {
         struct sigaction ours = *act;
         ours.sa_sigaction = linuwux_segv_wrapper;
@@ -153,7 +156,8 @@ int prctl(int option, ...)
 
     long ret = real_prctl(option, a2, a3, a4, a5);
 
-    if (ret >= 0 && option == PR_SET_SYSCALL_USER_DISPATCH && a2 == PR_SYS_DISPATCH_ON) {
+    if (linuwux_is_game_process() &&
+        ret >= 0 && option == PR_SET_SYSCALL_USER_DISPATCH && a2 == PR_SYS_DISPATCH_ON) {
         unsigned char *selector_addr = (unsigned char *)a5;
         unsigned char *teb = (unsigned char *)linuwux_get_teb();
         ptrdiff_t teb_offset = selector_addr - teb;

--- a/src/modules/linuwux.h
+++ b/src/modules/linuwux.h
@@ -20,6 +20,8 @@
 #ifndef LINUWUX_H
 #define LINUWUX_H
 
+#include <stdlib.h>
+
 /* From -DLINUWUX_VERSION; "dev" if built by hand. */
 #ifndef LINUWUX_VERSION
 #define LINUWUX_VERSION "dev"
@@ -29,8 +31,29 @@
 #define ARCH_SET_CPUID 0x1012
 #endif
 
+/* Proton/GE builtin system PE range — exclude from CPUID/SIGSYS.
+ * Exclusion (not allow-list) so relocated DRM still gets spoofed. */
+#define LINUWUX_WINE_SYSTEM_RIP_MIN 0x00006FFFFF000000ULL
+#define LINUWUX_WINE_SYSTEM_RIP_MAX 0x0000700000000000ULL
+
+static inline int linuwux_rip_is_wine_system(unsigned long long rip)
+{
+    return rip >= LINUWUX_WINE_SYSTEM_RIP_MIN && rip < LINUWUX_WINE_SYSTEM_RIP_MAX;
+}
+
+/* LINUWUX_REDIRECT_ALL=1 disables the Wine-system exclusion. */
+static inline int linuwux_redirect_all_enabled(void)
+{
+    const char *env = getenv("LINUWUX_REDIRECT_ALL");
+    return env && env[0] == '1' && env[1] == '\0';
+}
+
 /* Shared by every module; implemented in common.c. */
 void linuwux_log(const char *fmt, ...);
+
+/* is_game: set once in the constructor. Gates log/hooks/overrides. */
+void linuwux_set_game_process(int is_game);
+int linuwux_is_game_process(void);
 
 /* Win64 TEB: %gs:0x30 (NtTib.Self). Header-only: each TU gets its own
  * static copy, which is fine for a one-instruction inline. */

--- a/src/modules/sigsys.c
+++ b/src/modules/sigsys.c
@@ -31,20 +31,7 @@
 #include "cpuid.h"
 #include "sigsys.h"
 
-/* Typical Proton/GE ntdll/kernel PE range — skip redirects here unless forced. */
-#define LINUWUX_WINE_SYSTEM_RIP_MIN 0x00006FFFFF000000ULL
-#define LINUWUX_WINE_SYSTEM_RIP_MAX 0x0000700000000000ULL
-
-static int linuwux_rip_is_wine_system(unsigned long long rip)
-{
-    return rip >= LINUWUX_WINE_SYSTEM_RIP_MIN && rip < LINUWUX_WINE_SYSTEM_RIP_MAX;
-}
-
-static int linuwux_redirect_all_enabled(void)
-{
-    const char *env = getenv("LINUWUX_REDIRECT_ALL");
-    return env && env[0] == '1' && env[1] == '\0';
-}
+/* Wine-system RIP helpers: linuwux.h */
 
 /* TEB offset of SUD selector; -1 if unused (seccomp trees). */
 static _Atomic ptrdiff_t g_sud_teb_offset = -1;


### PR DESCRIPTION
only loads our library if its within the right process. inspired by soemone launching their entire lutris with the library preloaded, which ks not intended use.