### PR TITLE
feat: denuvowo.dll compat

### DIFF
--- a/src/linuwux.c
+++ b/src/linuwux.c
@@ -60,12 +60,17 @@ static void linuwux_append_override(char *buf, size_t bufsize, const char *entry
  *   reflex.dll / reflex64.dll  — reflex-loader scene layout
  *   DenuvOwO.ini               — older winmm-loader layout (no reflex.dll)
  */
-static int linuwux_dir_has_reflex(const char *dir, int *legacy_denuvowo)
+enum linuwux_game_marker {
+    LINUWUX_GAME_NONE = 0,
+    LINUWUX_GAME_REFLEX,
+    LINUWUX_GAME_DENUVOWO,
+};
+
+static int linuwux_dir_game_marker(const char *dir)
 {
     DIR *d;
     struct dirent *ent;
-    int found = 0;
-    int legacy = 0;
+    int marker = LINUWUX_GAME_NONE;
 
     d = opendir(dir);
     if (!d)
@@ -73,36 +78,28 @@ static int linuwux_dir_has_reflex(const char *dir, int *legacy_denuvowo)
 
     while ((ent = readdir(d))) {
         if (!strcasecmp(ent->d_name, "DenuvOwO.ini")) {
-            found = 1;
-            legacy = 1;
+            marker = LINUWUX_GAME_DENUVOWO;
             linuwux_log("Found %s\n", ent->d_name);
             break;
         }
         if (!strcasecmp(ent->d_name, "reflex.dll") ||
             !strcasecmp(ent->d_name, "reflex64.dll")) {
-            found = 1;
+            marker = LINUWUX_GAME_REFLEX;
             linuwux_log("Found %s\n", ent->d_name);
         }
     }
     closedir(d);
 
-    if (legacy_denuvowo)
-        *legacy_denuvowo = legacy;
-
-    return found;
+    return marker;
 }
 
-static int linuwux_game_dir_has_reflex(const char *argv0, int *legacy_denuvowo)
+static int linuwux_game_dir_marker(const char *argv0)
 {
     const char *prefix;
     char path[PATH_MAX];
     char drive;
     char *slash;
     size_t i;
-    int found;
-
-    if (legacy_denuvowo)
-        *legacy_denuvowo = 0;
 
     if (!argv0 || !argv0[0] || argv0[1] != ':')
         return 0;
@@ -134,8 +131,7 @@ static int linuwux_game_dir_has_reflex(const char *argv0, int *legacy_denuvowo)
         return 0;
     *slash = '\0';
 
-    found = linuwux_dir_has_reflex(path, legacy_denuvowo);
-    return found;
+    return linuwux_dir_game_marker(path);
 }
 
 /* /proc/self/comm holds the kernel task name (<=15 chars + NUL); wineserver
@@ -167,13 +163,13 @@ static void linuwux_init(int argc, char **argv, char **envp)
 {
     char overrides[4096];
     const char *existing;
-    int n, is_game, is_wineserver, legacy_denuvowo;
+    int n, marker, is_game, is_wineserver;
 
     (void)envp;
 
     /* Wine: argv[0] is the loader; argv[1] is the Windows target path. */
-    is_game = linuwux_game_dir_has_reflex(argc > 1 ? argv[1] : NULL,
-                                          &legacy_denuvowo);
+    marker = linuwux_game_dir_marker(argc > 1 ? argv[1] : NULL);
+    is_game = marker != LINUWUX_GAME_NONE;
     linuwux_set_game_process(is_game);
     if (is_game && argc > 1 && argv[1]) {
         const char *exe = argv[1];
@@ -198,7 +194,7 @@ static void linuwux_init(int argc, char **argv, char **envp)
 
     /* Spoof leaves only needed in the game process (CPUID path gated). */
     if (is_game) {
-        if (legacy_denuvowo)
+        if (marker == LINUWUX_GAME_DENUVOWO)
             linuwux_cpuid_hint_denuvowo();
         linuwux_detect_cpu_vendor();
     }

--- a/src/linuwux.c
+++ b/src/linuwux.c
@@ -58,7 +58,7 @@ static void linuwux_append_override(char *buf, size_t bufsize, const char *entry
 /*
  * is_game markers beside the Windows target exe (existence only, never loaded):
  *   reflex.dll / reflex64.dll  — reflex-loader scene layout
- *   DenuvOwO.ini               — older winmm-loader layout (no reflex.dll)
+ *   DenuvOwO.dll               — DenuvOwO loader layout (no reflex.dll)
  */
 enum linuwux_game_marker {
     LINUWUX_GAME_NONE = 0,
@@ -77,7 +77,7 @@ static int linuwux_dir_game_marker(const char *dir)
         return 0;
 
     while ((ent = readdir(d))) {
-        if (!strcasecmp(ent->d_name, "DenuvOwO.ini")) {
+        if (!strcasecmp(ent->d_name, "DenuvOwO.dll")) {
             marker = LINUWUX_GAME_DENUVOWO;
             linuwux_log("Found %s\n", ent->d_name);
             break;

--- a/src/linuwux.c
+++ b/src/linuwux.c
@@ -60,31 +60,39 @@ static void linuwux_append_override(char *buf, size_t bufsize, const char *entry
  *   reflex.dll / reflex64.dll  — reflex-loader scene layout
  *   DenuvOwO.ini               — older winmm-loader layout (no reflex.dll)
  */
-static int linuwux_dir_has_reflex(const char *dir)
+static int linuwux_dir_has_reflex(const char *dir, int *legacy_denuvowo)
 {
     DIR *d;
     struct dirent *ent;
     int found = 0;
+    int legacy = 0;
 
     d = opendir(dir);
     if (!d)
         return 0;
 
     while ((ent = readdir(d))) {
-        if (!strcasecmp(ent->d_name, "reflex.dll") ||
-            !strcasecmp(ent->d_name, "reflex64.dll") ||
-            !strcasecmp(ent->d_name, "DenuvOwO.ini")) {
+        if (!strcasecmp(ent->d_name, "DenuvOwO.ini")) {
             found = 1;
+            legacy = 1;
             linuwux_log("Found %s\n", ent->d_name);
             break;
+        }
+        if (!strcasecmp(ent->d_name, "reflex.dll") ||
+            !strcasecmp(ent->d_name, "reflex64.dll")) {
+            found = 1;
+            linuwux_log("Found %s\n", ent->d_name);
         }
     }
     closedir(d);
 
+    if (legacy_denuvowo)
+        *legacy_denuvowo = legacy;
+
     return found;
 }
 
-static int linuwux_game_dir_has_reflex(const char *argv0)
+static int linuwux_game_dir_has_reflex(const char *argv0, int *legacy_denuvowo)
 {
     const char *prefix;
     char path[PATH_MAX];
@@ -92,6 +100,9 @@ static int linuwux_game_dir_has_reflex(const char *argv0)
     char *slash;
     size_t i;
     int found;
+
+    if (legacy_denuvowo)
+        *legacy_denuvowo = 0;
 
     if (!argv0 || !argv0[0] || argv0[1] != ':')
         return 0;
@@ -123,7 +134,7 @@ static int linuwux_game_dir_has_reflex(const char *argv0)
         return 0;
     *slash = '\0';
 
-    found = linuwux_dir_has_reflex(path);
+    found = linuwux_dir_has_reflex(path, legacy_denuvowo);
     return found;
 }
 
@@ -156,12 +167,13 @@ static void linuwux_init(int argc, char **argv, char **envp)
 {
     char overrides[4096];
     const char *existing;
-    int n, is_game, is_wineserver;
+    int n, is_game, is_wineserver, legacy_denuvowo;
 
     (void)envp;
 
     /* Wine: argv[0] is the loader; argv[1] is the Windows target path. */
-    is_game = linuwux_game_dir_has_reflex(argc > 1 ? argv[1] : NULL);
+    is_game = linuwux_game_dir_has_reflex(argc > 1 ? argv[1] : NULL,
+                                          &legacy_denuvowo);
     linuwux_set_game_process(is_game);
     if (is_game && argc > 1 && argv[1]) {
         const char *exe = argv[1];
@@ -185,8 +197,11 @@ static void linuwux_init(int argc, char **argv, char **envp)
         linuwux_faketime_prefix_init();
 
     /* Spoof leaves only needed in the game process (CPUID path gated). */
-    if (is_game)
+    if (is_game) {
+        if (legacy_denuvowo)
+            linuwux_cpuid_hint_denuvowo();
         linuwux_detect_cpu_vendor();
+    }
 
     /* Overrides only in the game process (Wine reads env at PE load). */
     if (is_game) {

--- a/src/modules/cpuid.c
+++ b/src/modules/cpuid.c
@@ -74,7 +74,6 @@ void linuwux_cpuid_hint_denuvowo(void)
     /* DenuvOwO's 0x69696969 leaf is a target marker; its actual
      * 0x336933 handshake uses the modern SimpleSvm trampoline. */
     atomic_store(&g_proto.protocol, LINUWUX_PROTO_MODERN);
-    atomic_store(&g_proto.rax_is_resume, 1);
     linuwux_log("selected DenuvOwO SimpleSvm identity from marker\n");
 }
 
@@ -695,28 +694,15 @@ static const struct linuwux_cpuid_static_leaf cpuid_static_leaves[] = {
         .ecx = &g_spoof_leaf1.ecx, .edx = &g_spoof_leaf1.edx,
     },
     {
-        /* Legacy DenuvOwO expects the SimpleSvm hypervisor identity. */
+        /* Shared across protocols — not identity-sensitive brand strings. */
         .leaf = 0x40000000,
-        .profile = LINUWUX_CPUID_STATIC_LEGACY,
+        .profile = LINUWUX_CPUID_STATIC_ANY,
         .eax = &g_spoof_hypervisor_info.eax, .ebx = &g_spoof_hypervisor_info.ebx,
         .ecx = &g_spoof_hypervisor_info.ecx, .edx = &g_spoof_hypervisor_info.edx,
     },
     {
         .leaf = 0x40000001,
-        .profile = LINUWUX_CPUID_STATIC_LEGACY,
-        .eax = &g_spoof_hypervisor_feat.eax, .ebx = &g_spoof_hypervisor_feat.ebx,
-        .ecx = &g_spoof_hypervisor_feat.ecx, .edx = &g_spoof_hypervisor_feat.edx,
-    },
-    {
-        /* Modern Reflex uses the Hyper-V-compatible identity. */
-        .leaf = 0x40000000,
-        .profile = LINUWUX_CPUID_STATIC_MODERN,
-        .eax = &g_spoof_hypervisor_info.eax, .ebx = &g_spoof_hypervisor_info.ebx,
-        .ecx = &g_spoof_hypervisor_info.ecx, .edx = &g_spoof_hypervisor_info.edx,
-    },
-    {
-        .leaf = 0x40000001,
-        .profile = LINUWUX_CPUID_STATIC_MODERN,
+        .profile = LINUWUX_CPUID_STATIC_ANY,
         .eax = &g_spoof_hypervisor_feat.eax, .ebx = &g_spoof_hypervisor_feat.ebx,
         .ecx = &g_spoof_hypervisor_feat.ecx, .edx = &g_spoof_hypervisor_feat.edx,
     },

--- a/src/modules/cpuid.c
+++ b/src/modules/cpuid.c
@@ -386,8 +386,6 @@ static const struct linuwux_kuser_op kuser_ops_legacy_single[] = {
     KUSER_STORE4(KUSER_NtBuildNumber, 0x00006658),
     KUSER_STORE4(KUSER_NtMajorVersion, 0x0A),
     KUSER_STORE4(KUSER_NtMinorVersion, 0),
-    /* Legacy DenuvOwO.dll waits for the shared cookie before continuing. */
-    KUSER_STORE4(KUSER_CookieMagic,  KUSER_VAL_COOKIE_MAGIC),
 };
 
 static const struct linuwux_kuser_op kuser_ops_legacy_dual[] = {
@@ -414,8 +412,6 @@ static const struct linuwux_kuser_op kuser_ops_legacy_dual[] = {
     KUSER_STORE4(KUSER_SharedDataFlags + 4, 0),
     KUSER_STORE4(KUSER_NtProductType, 0x1),
     KUSER_STORE4(KUSER_NtMinorVersion, 0),
-    /* Keep the DenuvOwO cookie available to the dual-handler layout too. */
-    KUSER_STORE4(KUSER_CookieMagic,  KUSER_VAL_COOKIE_MAGIC),
 };
 
 static const struct linuwux_kuser_profile kuser_profile_legacy_single = {

--- a/src/modules/cpuid.c
+++ b/src/modules/cpuid.c
@@ -66,6 +66,18 @@ static struct linuwux_protocol_state g_proto = {
     .full_id = 0xffffffffu,
 };
 
+void linuwux_cpuid_hint_denuvowo(void)
+{
+    if (atomic_load(&g_proto.protocol) != LINUWUX_PROTO_NONE)
+        return;
+
+    /* DenuvOwO's 0x69696969 leaf is a target marker; its actual
+     * 0x336933 handshake uses the modern SimpleSvm trampoline. */
+    atomic_store(&g_proto.protocol, LINUWUX_PROTO_MODERN);
+    atomic_store(&g_proto.rax_is_resume, 1);
+    linuwux_log("selected DenuvOwO SimpleSvm identity from marker\n");
+}
+
 /* Spoofed CPUID identity, filled once in the constructor. */
 struct linuwux_cpuid_regs {
     unsigned int eax, ebx, ecx, edx;
@@ -375,6 +387,8 @@ static const struct linuwux_kuser_op kuser_ops_legacy_single[] = {
     KUSER_STORE4(KUSER_NtBuildNumber, 0x00006658),
     KUSER_STORE4(KUSER_NtMajorVersion, 0x0A),
     KUSER_STORE4(KUSER_NtMinorVersion, 0),
+    /* Legacy DenuvOwO.dll waits for the shared cookie before continuing. */
+    KUSER_STORE4(KUSER_CookieMagic,  KUSER_VAL_COOKIE_MAGIC),
 };
 
 static const struct linuwux_kuser_op kuser_ops_legacy_dual[] = {
@@ -401,6 +415,8 @@ static const struct linuwux_kuser_op kuser_ops_legacy_dual[] = {
     KUSER_STORE4(KUSER_SharedDataFlags + 4, 0),
     KUSER_STORE4(KUSER_NtProductType, 0x1),
     KUSER_STORE4(KUSER_NtMinorVersion, 0),
+    /* Keep the DenuvOwO cookie available to the dual-handler layout too. */
+    KUSER_STORE4(KUSER_CookieMagic,  KUSER_VAL_COOKIE_MAGIC),
 };
 
 static const struct linuwux_kuser_profile kuser_profile_legacy_single = {
@@ -679,15 +695,28 @@ static const struct linuwux_cpuid_static_leaf cpuid_static_leaves[] = {
         .ecx = &g_spoof_leaf1.ecx, .edx = &g_spoof_leaf1.edx,
     },
     {
-        /* Shared across protocols — not identity-sensitive brand strings. */
+        /* Legacy DenuvOwO expects the SimpleSvm hypervisor identity. */
         .leaf = 0x40000000,
-        .profile = LINUWUX_CPUID_STATIC_ANY,
+        .profile = LINUWUX_CPUID_STATIC_LEGACY,
         .eax = &g_spoof_hypervisor_info.eax, .ebx = &g_spoof_hypervisor_info.ebx,
         .ecx = &g_spoof_hypervisor_info.ecx, .edx = &g_spoof_hypervisor_info.edx,
     },
     {
         .leaf = 0x40000001,
-        .profile = LINUWUX_CPUID_STATIC_ANY,
+        .profile = LINUWUX_CPUID_STATIC_LEGACY,
+        .eax = &g_spoof_hypervisor_feat.eax, .ebx = &g_spoof_hypervisor_feat.ebx,
+        .ecx = &g_spoof_hypervisor_feat.ecx, .edx = &g_spoof_hypervisor_feat.edx,
+    },
+    {
+        /* Modern Reflex uses the Hyper-V-compatible identity. */
+        .leaf = 0x40000000,
+        .profile = LINUWUX_CPUID_STATIC_MODERN,
+        .eax = &g_spoof_hypervisor_info.eax, .ebx = &g_spoof_hypervisor_info.ebx,
+        .ecx = &g_spoof_hypervisor_info.ecx, .edx = &g_spoof_hypervisor_info.edx,
+    },
+    {
+        .leaf = 0x40000001,
+        .profile = LINUWUX_CPUID_STATIC_MODERN,
         .eax = &g_spoof_hypervisor_feat.eax, .ebx = &g_spoof_hypervisor_feat.ebx,
         .ecx = &g_spoof_hypervisor_feat.ecx, .edx = &g_spoof_hypervisor_feat.edx,
     },

--- a/src/modules/cpuid.h
+++ b/src/modules/cpuid.h
@@ -28,6 +28,9 @@
  * Must run in the constructor, before any other thread exists. */
 void linuwux_detect_cpu_vendor(void);
 
+/* Select the DenuvOwO SimpleSvm identity before its early CPUID checks. */
+void linuwux_cpuid_hint_denuvowo(void);
+
 /* Handle a CPUID fault. Returns 1 if handled. */
 int linuwux_cpuid_spoof(siginfo_t *info, ucontext_t *ctx);
 


### PR DESCRIPTION
DenuvOwO.dll compatibility:

Move to enum for none | reflex | denuvowo

For owo discovered games, force modern runtime, don't let 0x69696969 CPUID leaf incorrectly coerce legacy